### PR TITLE
fix: remove deprecated goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,13 +10,6 @@ builds:
       - darwin
     main: "./cmd/ctp"
     binary: "ctp"
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This PR removes deprecated config fields from goreleaser.

https://goreleaser.com/deprecations/#archivesreplacements

There is a way to retain the previous naming, but I figured it wasn't worth it at this time.